### PR TITLE
Bug fix for multiGPU DFA

### DIFF
--- a/Models/Sequential2.lua
+++ b/Models/Sequential2.lua
@@ -25,7 +25,7 @@ function Sequential2:backward(input, gradOutput, scale, backprop)
    for i=#self.modules-1,1,-1 do
       local previousModule = self.modules[i]
       if torch.typename(currentModule) == 'ErrorFeedback' then
-        if backprop==false then
+        if not backprop then
           currentGradOutput = currentModule:backward(previousModule.output, gradOutput, scale)
           currentModule.gradInput = currentGradOutput
         end

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This code and readme is copied and modified based on https://github.com/eladhoff
 
 Supported datasets are {Cifar10/100, STL10, SVHN, MNIST}
 
-##Data
+## Data
 You can get the needed data using @soumith's repo: https://github.com/soumith/cifar.torch.git
 
-##Dependencies
+## Dependencies
 * Torch (http://torch.ch)
 * "DataProvider.torch" (https://github.com/eladhoffer/DataProvider.torch) for DataProvider class.
 * "cudnn.torch" (https://github.com/soumith/cudnn.torch) for faster training. Can be avoided by changing "cudnn" to "nn" in models.
@@ -29,7 +29,7 @@ luarocks install unsup
 luarocks install https://raw.github.com/andresy/mnist/master/rocks/mnist-scm-1.rockspec
 ```
 
-##Training
+## Training
 You can reproduce the best results for direct feedback-alignment for each dataset with:
 ```lua
 th Main.lua -dataset MNIST -network mlp.lua -LR 1e-4 -eps 0.08
@@ -43,7 +43,7 @@ or,
 th Main.lua -dataset Cifar100 -network conv.lua -LR 2.5e-5 -whiten
 ```
 
-##Additional flags
+## Additional flags
 
 |Flag             | Default Value        |Description
 |:----------------|:--------------------:|:----------------------------------------------

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ th Main.lua -dataset Cifar100 -network conv.lua -LR 2.5e-5 -whiten
 ```
 
 ##Additional flags
+
 |Flag             | Default Value        |Description
 |:----------------|:--------------------:|:----------------------------------------------
 |modelsFolder     |  ./Models/           | models Folder


### PR DESCRIPTION
I've found a bug in the multiGPU behavior of this code.

The model is trained by backprop when using more than one GPU, because `backprop` evaluates to `false` on 1 GPU and to `nil` on two.

The fix is simply editing `if backprop==false then` to `if not backprop then`.